### PR TITLE
不一致シーケンスが後置型変換開始キーで確定された時に変換対象外になるバグ修正

### DIFF
--- a/imcrvtip/KeyHandlerConv.cpp
+++ b/imcrvtip/KeyHandlerConv.cpp
@@ -723,21 +723,16 @@ void CTextService::_DynamicComp(TfEditCookie ec, ITfContext *pContext, BOOL sel)
 
 void CTextService::_ConvRoman()
 {
-	BOOL r = _ConvShift(WCHAR_MAX);
+	if(!_ConvShift(WCHAR_MAX))
+	{
+		roman.clear();
+	}
 
 	if(okuriidx != 0 && okuriidx + 1 == cursoridx)
 	{
 		kana.erase(cursoridx - 1, 1);
 		cursoridx--;
 		okuriidx = 0;
-	}
-
-	if(!r)
-	{
-		//不一致のシーケンスはそのまま確定(短い単語を大文字入力等)
-		kana.insert(cursoridx, roman);
-		cursoridx += roman.size();
-		roman.clear();
 	}
 }
 
@@ -892,7 +887,11 @@ BOOL CTextService::_ConvShift(WCHAR ch)
 		return TRUE;
 	}
 
-	return FALSE;
+	//不一致のシーケンスはそのまま確定(短い単語を大文字入力等)
+	kana.insert(cursoridx, roman);
+	cursoridx += roman.size();
+	roman.clear();
+	return TRUE;
 }
 
 BOOL CTextService::_ConvN()

--- a/imcrvtip/TextService.h
+++ b/imcrvtip/TextService.h
@@ -148,12 +148,13 @@ public:
 	void _GetActiveFlags();
 	void _InitFont();
 	void _UninitFont();
-	HRESULT _CommitRoman(TfEditCookie ec, ITfContext *pContext);
 
 	// KeyHandlerChar
 	HRESULT _HandleChar(TfEditCookie ec, ITfContext *pContext, WPARAM wParam, WCHAR ch, WCHAR chO);
 	HRESULT _HandleCharReturn(TfEditCookie ec, ITfContext *pContext, BOOL back = FALSE);
 	HRESULT _HandleCharShift(TfEditCookie ec, ITfContext *pContext);
+	bool _IsPostConvFunc(WCHAR ch);
+	HRESULT _ConvRomanKanaWithWait(WCHAR ch, std::wstring *pRoman, ROMAN_KANA_CONV *pRkc);
 
 	// KeyHandlerCompostion
 	HRESULT _Update(TfEditCookie ec, ITfContext *pContext, BOOL fixed = FALSE, BOOL back = FALSE);
@@ -201,15 +202,15 @@ public:
 	BOOL _SearchRomanByKana(const ROMAN_KANA_NODE &tree, int srcmode, const WCHAR *src, std::wstring &dst);
 
 	// KeyHandlerPostConv
-	HRESULT _HandlePostMaze(TfEditCookie ec, ITfContext *pContext, int count, PostConvContext postconvctx, bool isKatuyo, bool resizeWithInflection);
-	void _AcquirePrecedingYomi(ITfContext *pContext, PostConvContext postconvctx, std::wstring *yomi, size_t count);
-	HRESULT _HandlePostKanaKan(TfEditCookie ec, ITfContext *pContext, PostConvContext postconvctx, bool isKatuyo, bool resizeWithInflection);
-	HRESULT _HandlePostKata(TfEditCookie ec, ITfContext *pContext, int count, PostConvContext postconvctx, bool skipKata);
-	HRESULT _HandlePostKataShrink(TfEditCookie ec, ITfContext *pContext, int count, PostConvContext postconvctx);
-	HRESULT _HandlePostBushu(TfEditCookie ec, ITfContext *pContext, PostConvContext postconvctx);
-	HRESULT _HandlePostSeq2Kanji(TfEditCookie ec, ITfContext *pContext, int count, PostConvContext postconvctx);
-	HRESULT _HandlePostKanji2Seq(TfEditCookie ec, ITfContext *pContext, int count, PostConvContext postconvctx);
-	HRESULT _HandlePostHelp(TfEditCookie ec, ITfContext *pContext, PostConvContext postconvctx, int count);
+	HRESULT _HandlePostMaze(TfEditCookie ec, ITfContext *pContext, int count, PostConvContext postconvctx, const std::wstring &abortedRomanForPostConv, bool isKatuyo, bool resizeWithInflection);
+	void _AcquirePrecedingYomi(ITfContext *pContext, PostConvContext postconvctx, const std::wstring &abortedRomanForPostConv, std::wstring *yomi, size_t count);
+	HRESULT _HandlePostKanaKan(TfEditCookie ec, ITfContext *pContext, PostConvContext postconvctx, const std::wstring &abortedRomanForPostConv, bool isKatuyo, bool resizeWithInflection);
+	HRESULT _HandlePostKata(TfEditCookie ec, ITfContext *pContext, int count, PostConvContext postconvctx, const std::wstring &abortedRomanForPostConv, bool skipKata);
+	HRESULT _HandlePostKataShrink(TfEditCookie ec, ITfContext *pContext, int count, PostConvContext postconvctx, const std::wstring &abortedRomanForPostConv);
+	HRESULT _HandlePostBushu(TfEditCookie ec, ITfContext *pContext, PostConvContext postconvctx, const std::wstring &abortedRomanForPostConv);
+	HRESULT _HandlePostSeq2Kanji(TfEditCookie ec, ITfContext *pContext, int count, PostConvContext postconvctx, const std::wstring &abortedRomanForPostConv);
+	HRESULT _HandlePostKanji2Seq(TfEditCookie ec, ITfContext *pContext, int count, PostConvContext postconvctx, const std::wstring &abortedRomanForPostConv);
+	HRESULT _HandlePostHelp(TfEditCookie ec, ITfContext *pContext, PostConvContext postconvctx, const std::wstring &abortedRomanForPostConv, int count);
 	BOOL isroman(std::wstring &ch);
 	enum AcquiredFrom
 	{
@@ -219,12 +220,13 @@ public:
 		AF_PRECEDING,
 		AF_SELECTION,
 	};
-	AcquiredFrom _AcquirePrecedingText(ITfContext *pContext, PostConvContext postconvctx, std::wstring *text, BOOL useSelectedText = FALSE);
+	AcquiredFrom _AcquirePrecedingText(ITfContext *pContext, PostConvContext postconvctx, const std::wstring &abortedRomanForPostConv, std::wstring *text, BOOL useSelectedText = FALSE);
 	void _AddToPostBuf(const std::wstring &text);
-	HRESULT _ReplacePrecedingText(TfEditCookie ec, ITfContext *pContext, const std::wstring &delstr, const std::wstring &replstr, PostConvContext postconvctx, BOOL startMaze = false);
+	HRESULT _ReplacePrecedingText(TfEditCookie ec, ITfContext *pContext, const std::wstring &delstr, const std::wstring &replstr, PostConvContext postconvctx, const std::wstring &abortedRomanForPostConv, BOOL startMaze = false);
 	void _StartConvWithYomi(TfEditCookie ec, ITfContext *pContext, const std::wstring &yomi);
 	HRESULT _ReplacePrecedingTextIMM32(TfEditCookie ec, ITfContext *pContext, size_t delete_count, const std::wstring &replstr, BOOL startMaze = false);
 	HRESULT _ShowAutoHelp(const std::wstring &kanji, const std::wstring &yomi);
+	void _CommitStr(TfEditCookie ec, ITfContext *pContext, const std::wstring &s, PostConvContext postconvctx);
 
 	// KeyHandlerDictionary
 	void _ConnectDic();


### PR DESCRIPTION
再現条件:
* ローマ字かなテーブルとして、tsf-romaji.txtを読込
* 以下の定義をローマ字かなテーブルに追加/変更。
ki き キ ｷ 2
き\ き\ キ ｷ 2
き\a 切 切 切 0
き\s 着 着 着 0
https://mobile.twitter.com/shiki_okasaka/status/851166714733539328?p=p
* 後置型変換開始が1キーに割り当てられている
  (fj等複数キーから成るシーケンスなら問題なし)
* notepadで、
* taiki<Space>のように、「き」が待機中に、
  1キーに割り当てた後置型変換開始すると、待機中の文字列が、
  後置型変換の対象に含まれない現象が発生する。
https://mobile.twitter.com/shiki_okasaka/status/851170087859920896?p=p