### PR TITLE
設定ダイアログのデフォルト表示内容がデフォルトconfig.xmlと合っていない問題修正

### DIFF
--- a/imcrvcnf/DlgProcConvPoint.cpp
+++ b/imcrvcnf/DlgProcConvPoint.cpp
@@ -248,15 +248,21 @@ void LoadConfigConvPoint()
 			i++;
 		}
 	}
-	else if (FAILED(hr))
-	{
-		for (int i = 0; i < 26; i++)
-		{
-			conv_point[i][0][0] = L'A' + (WCHAR)i;
-			conv_point[i][1][0] = L'a' + (WCHAR)i;
-			conv_point[i][2][0] = L'a' + (WCHAR)i;
-		}
-	}
+	//sysconfigxmlの内容に合わせて空にする。一部の大文字はカタカナ用に使用する。
+	//%SystemRoot%\IME\IMTSFTUTCODE\config.xml ← ..\installer\config-share\config.xml
+	//radconfigxml(%APPDATA%\tsf-tutcode\config.xml)が無い時は、
+	//  tsf-tutcodeはsysconfigxmlの設定内容で動作。
+	//  この時、imtutcnf.exe起動時に表示される(ハードコードされたデフォルトの)設定内容を、
+	//  動作中の設定内容(sysconfigxml)と合わせておく。でないと、ずれが生じる。
+	//else if (FAILED(hr))
+	//{
+	//	for (int i = 0; i < 26; i++)
+	//	{
+	//		conv_point[i][0][0] = L'A' + (WCHAR)i;
+	//		conv_point[i][1][0] = L'a' + (WCHAR)i;
+	//		conv_point[i][2][0] = L'a' + (WCHAR)i;
+	//	}
+	//}
 }
 
 void LoadConvPoint(HWND hDlg)

--- a/installer/config-share/config.xml
+++ b/installer/config-share/config.xml
@@ -66,7 +66,7 @@
     <key name="annotatlst" value="1" />
     <key name="showmodemark" value="0" />
     <key name="showroman" value="1" />
-    <key name="showromanjlat" value="0" />
+    <key name="showromanjlat" value="1" />
     <key name="showromancomp" value="0" />
     <key name="showmodeinl" value="1" />
     <key name="showmodeinltm" value="3000" />


### PR DESCRIPTION
* 設定ダイアログの変換位置指定ConvPointのデフォルト設定値を、デフォルトconfig.xml(sysconfigxml)の内容に合わせて空にするように修整。
  * radconfigxml(%APPDATA%\tsf-tutcode\config.xml)が無い時は、
    * tsf-tutcodeはsysconfigxmlの設定内容で動作。
    * この時、imtutcnf.exe起動時に表示される(ハードコードされたデフォルトの)設定内容を、動作中の設定内容(sysconfigxml)と合わせるように修整した。
      でないと、ずれが生じる。
* (デフォルトconfig.xmlで変換位置指定を空にしているのは、一部の大文字をカタカナ用に使用しているため。)