### PR TITLE
Avoid wix extension error by wix version mismatch

### DIFF
--- a/installer/_wix_install.cmd
+++ b/installer/_wix_install.cmd
@@ -27,7 +27,7 @@ WixToolset.VisualStudio.wixext
 
 for %%i in (%EXTENSIONS%) do (
   wix extension remove --global %%i
-  wix extension add --global %%i
+  wix extension add --global %%i/4.0.4
 )
 
 echo [Extensions]


### PR DESCRIPTION
wix.exe : error WIX0144: The extension 'WixToolset.UI.wixext' could not be found.

WixToolset.UI.wixext 5.0.0-rc.1 (damaged)